### PR TITLE
fix mapping for vital vars in vital()

### DIFF
--- a/R/vital.R
+++ b/R/vital.R
@@ -39,7 +39,7 @@ vital <- function(
   tsibble(..., key = !!enquo(key), index = !!enquo(index), regular = regular, .drop = .drop) |>
     as_vital(
       .age = .age, .sex = .sex, .deaths = .deaths,
-      births = .births, population = .population
+      .births = .births, .population = .population
     )
 }
 


### PR DESCRIPTION
Caused created vital to be incomplete, with
population and births to be ignored as vital_vars
if specified.

``` r
library(vital)
#> Registered S3 method overwritten by 'tsibble':
#>   method               from 
#>   as_tibble.grouped_df dplyr
```

``` r
library(tibble)
  aus_fertility |>
  as_tibble() |>
  vital(
    .age = "Age",
    .births = "Births",
    .population = "Exposure",
    index = "Year",
    key = "Age"
  ) |>
  vital_vars()
#>   age 
#> "Age"
```

<sup>Created on 2024-11-19 with [reprex v2.1.1](https://reprex.tidyverse.org)</sup>
