### PR TITLE
fix ordering of fitted rows in augment.mdl_vtl_ts

### DIFF
--- a/R/augment.R
+++ b/R/augment.R
@@ -16,11 +16,11 @@ augment.mdl_vtl_df <- function(x, ...) {
 
 #' @export
 augment.mdl_vtl_ts <- function(x, ...) {
-  out <- response(x) |>
-    mutate(
-      .fitted = x$fit$fitted[[".fitted"]],
-      .resid = x$fit$fitted[[".resid"]],
-      .innov = x$fit$fitted[[".innov"]]
+  x_response <- response(x)
+  out <- x_response |>
+    left_join(
+      x$fit$fitted,
+      by = c(age_var(x_response), index_var(x_response))
     )
   # Back transform fitted value
   fits <- as.list(out)[".fitted"]
@@ -62,5 +62,10 @@ response.mdl_vtl_ts <- function(object, ...) {
     ".response"
     else mv] <- resp
   # Fix key
-  as_vital(out, key = vvar$age, index = index_var(object$data))
+  as_vital(
+    out,
+    key = vvar$age,
+    index = index_var(object$data),
+    .age = vvar$age
+  )
 }


### PR DESCRIPTION
A second attempt at a fix for #39 that incorporates the changes for #41.

- Had to make an additional change to response.mdl_vtl_ts to set the age vital component, so that I could pick it out to use as key in the join in augment. I hope that makes sense.