### PR TITLE
Allow usage of any name for 'age' with life_table() (lt())

### DIFF
--- a/R/life_table.R
+++ b/R/life_table.R
@@ -154,7 +154,7 @@ lt <- function(dt, sex, age, mortality) {
   # Return the results in a tibble
   result <- tibble::tibble(mx = mx, qx = qx, lx = lx, dx = dx, Lx = Lx, Tx = Tx,
     ex = ex, rx = rx, nx = nx, ax = ax) |>
-    mutate(Age = dt[[age]])
+    mutate(!!age := dt[[age]])
 
   return(result)
 }


### PR DESCRIPTION
Use tidyeval := to refer to user's age var in `age` on `mutate()` LHS

- Instead of hardcoded 'Age' which breaks if user had any other name for the age vital var.
- Fixes #45