### PR TITLE
Strip off the array class from `$fit` and `$se.fit`

### DIFF
--- a/R/smooth.R
+++ b/R/smooth.R
@@ -124,8 +124,8 @@ smooth_mortality_x <- function(
   )
   out <- tibble(
     age = age_grid,
-    .smooth = exp(smooth.fit$fit), #* (1 + 0.5 * smooth.fit$se.fit^2),
-    .smooth_se = .smooth * smooth.fit$se.fit
+    .smooth = exp(as.vector(smooth.fit$fit)), #* (1 + 0.5 * smooth.fit$se.fit^2),
+    .smooth_se = .smooth * as.vector(smooth.fit$se.fit)
   )
   colnames(out)[1] <- age
   return(out)


### PR DESCRIPTION
Hi there, we are working on the next version of dplyr and your package was flagged in our reverse dependency checks.

This one was a bit tricky. There's an `if_else()` call in `train_fdm()` that does `.innov < -1e20` and that produces a logical _array_. `if_else()` is now stricter about this, and requires a logical _vector_ for its first argument.

If you walk it all the way back up, it comes from the fact that `$fit` and `$se.fit` are 1D arrays, so converting them to vectors on the way out from `smooth_mortality()` feels like the right way to fix this.

dplyr will be released on January 31, 2026. If you could please send an update of your package to CRAN before then, that would help us out a lot! Thanks!