### PR TITLE
Update deprecated lst_mdl class to mdl_lst

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
   distributional,
   dplyr,
   fable,
-  fabletools (>= 0.3.3),
+  fabletools (>= 0.7.0),
   ggplot2,
   HMDHFDplus (>= 2.0.8),
   mgcv,

--- a/R/model.R
+++ b/R/model.R
@@ -238,7 +238,7 @@ nest_keys <- function(.data, nm = "data") {
 }
 
 list_of_models <- function(x = list()) {
-  vctrs::new_vctr(x, class = "lst_mdl")
+  vctrs::new_vctr(x, class = "mdl_lst")
 }
 
 #' @export


### PR DESCRIPTION
The lst_mdl class will be replaced by mdl_lst in fabletools v0.7.0.

This change is a soft deprecation, and existing code will continue to work. A patch release of vital is *not* urgently required.

Ref: https://github.com/tidyverts/fabletools/issues/433